### PR TITLE
Allowing access policies to be more than one entry

### DIFF
--- a/keyvault-accesspolicies.json
+++ b/keyvault-accesspolicies.json
@@ -71,7 +71,7 @@
         {
             "type": "Microsoft.KeyVault/vaults/accessPolicies",
             "apiVersion": "2016-10-01",
-            "name": "[concat(parameters('keyVaultName'), '/add')]",
+            "name": "[concat(parameters('keyVaultName'), '/add/', copyIndex())]",
             "properties": {
                 "mode": "Incremental",
                 "accessPolicies": [

--- a/keyvault-accesspolicies.json
+++ b/keyvault-accesspolicies.json
@@ -74,7 +74,7 @@
         {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2018-05-01",
-            "name": "accesspolicies",
+            "name": "[concat('accesspolicies-', copyIndex())]",
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {

--- a/keyvault-accesspolicies.json
+++ b/keyvault-accesspolicies.json
@@ -67,20 +67,33 @@
             }
         }
     },
+    "variables": {
+        "templateBaseUrl": "https://raw.githubusercontent.com/Winvision/azure-arm-templates/test-array/"
+    },
     "resources": [
         {
-            "type": "Microsoft.KeyVault/vaults/accessPolicies",
-            "apiVersion": "2016-10-01",
-            "name": "[concat(parameters('keyVaultName'), '/add/', copyIndex())]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "accesspolicies",
             "properties": {
                 "mode": "Incremental",
-                "accessPolicies": [
-                    {
-                        "tenantId": "[parameters('tenantId')]",
-                        "objectId": "[parameters('objectIds')[copyIndex()]]",
-                        "permissions": "[parameters('permissions')]"
+                "templateLink": {
+                    "uri": "[uri(variables('templateBaseUrl'), 'keyvault-accesspolicy.json')]"
+                },
+                "parameters": {
+                    "keyVaultName": {
+                        "value": "[parameters('keyVaultName')]"
+                    },
+                    "tenantId": {
+                        "value": "[parameters('tenantId')]"
+                    },
+                    "objectId": {
+                        "value": "[parameters('objectIds')[copyIndex()]]"
+                    },
+                    "permissions": {
+                        "value": "[parameters('permissions')]"
                     }
-                ]
+                }
             },
             "copy": {
                 "name": "policiesCopy",

--- a/keyvault-accesspolicy.json
+++ b/keyvault-accesspolicy.json
@@ -32,7 +32,7 @@
         {
             "type": "Microsoft.KeyVault/vaults/accessPolicies",
             "apiVersion": "2016-10-01",
-            "name": "[concat(parameters('keyVaultName'), '/add')]",
+            "name": "[concat(parameters('keyVaultName'), '/replace')]",
             "properties": {
                 "mode": "Incremental",
                 "accessPolicies": [

--- a/keyvault-accesspolicy.json
+++ b/keyvault-accesspolicy.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "keyVaultName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the Key Vault."
+            }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The tenant of the Key Vault."
+            }
+        },
+        "objectId": {
+            "type": "string",
+            "metadata": {
+                "description": "The object identifier that specifies which users get permissions on this Key Vault."
+            }
+        },
+        "permissions": {
+            "type": "object",
+            "metadata": {
+                "description": "The permissions to give to the users, by default this will make them Administrator."
+            }
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.KeyVault/vaults/accessPolicies",
+            "apiVersion": "2016-10-01",
+            "name": "[concat(parameters('keyVaultName'), '/add')]",
+            "properties": {
+                "mode": "Incremental",
+                "accessPolicies": [
+                    {
+                        "tenantId": "[parameters('tenantId')]",
+                        "objectId": "[parameters('objectId')]",
+                        "permissions": "[parameters('permissions')]"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
**Issue**
When adding more than one entry to the 'admins' parameter of the _keyvault-accesspolicies.json_ file, the deployment would fail, because the _/add_ name is not unique.

**Fix**
Fixed this by creating a sub-file _keyvault-accesspolicy.json_ and keeping the copy action in the parent file. Also changed /add to /replace to make sure no conflicts occur.