### PR TITLE
Workaround for apparent bug with conditions

### DIFF
--- a/appservice.json
+++ b/appservice.json
@@ -99,7 +99,9 @@
     },
     "variables": {
         "templateBaseUrl": "https://raw.githubusercontent.com/Winvision/azure-arm-templates/master/",
-        "managedIdentity": "[concat(resourceId('Microsoft.Web/sites', parameters('name')), '/providers/Microsoft.ManagedIdentity/Identities/default')]"
+        "managedIdentity": "[concat(resourceId('Microsoft.Web/sites', parameters('name')), '/providers/Microsoft.ManagedIdentity/Identities/default')]",
+        "slotManagedIdentity": "[concat(variables('slotManagedIdentityResourceIdBugWorkaround'), '/providers/Microsoft.ManagedIdentity/Identities/default')]",
+        "slotManagedIdentityResourceIdBugWorkaround": "[if(parameters('useStagingSlot'), resourceId('Microsoft.Web/sites/slots', parameters('name'), 'staging'), resourceId('Microsoft.Web/sites', parameters('name')))]"
     },
     "resources": [
         {
@@ -298,7 +300,7 @@
                     },
                     "objectIds": {
                         "value": [
-                            "[reference(concat(resourceId('Microsoft.Web/sites/slots', parameters('name'), 'staging'), '/providers/Microsoft.ManagedIdentity/Identities/default'), '2018-11-30').principalId]"
+                            "[reference(variables('slotManagedIdentity'), '2018-11-30').principalId]"
                         ]
                     },
                     "permissions": {


### PR DESCRIPTION
Fixes an issue where variable referencing managed identity of slot of webapp is still evaluated even when the step is conditioned out. Appears to be an issue with arm template parsing, claimed to be fixed but still happens even with newest api version on the resource. 