### PR TITLE
Delay app settings deployment to main slot till after the keyvault access policies.

### DIFF
--- a/appservice.json
+++ b/appservice.json
@@ -281,7 +281,8 @@
                 }
             },
             "dependsOn": [
-                "staging"
+                "staging",
+                "accesspolicies"
             ]
         },
         {


### PR DESCRIPTION
Delay app settings deployment to main slot till after the keyvault access policies have been assigned, this prevents an issue where the app settings deployment causes a restart but the app does not have access to keyvault yet, resulting in failed startup.