### PR TITLE
Make all config deployments depend on accessPolicies to avoid restaring without keyvault access

### DIFF
--- a/appservice.json
+++ b/appservice.json
@@ -214,7 +214,8 @@
                     "name": "slotconfignames",
                     "type": "config",
                     "dependsOn": [
-                        "[resourceId('Microsoft.Web/Sites', parameters('name'))]"
+                        "[resourceId('Microsoft.Web/Sites', parameters('name'))]",
+                        "accesspolicies"
                     ],
                     "properties": {
                         "appSettingNames": "[parameters('stickyStagingSlotSettings')]"
@@ -225,7 +226,8 @@
                     "name": "web",
                     "type": "config",
                     "dependsOn": [
-                        "[resourceId('Microsoft.Web/Sites', parameters('name'))]"
+                        "[resourceId('Microsoft.Web/Sites', parameters('name'))]",
+                        "accesspolicies"
                     ],
                     "properties": {
                         "autoHealEnabled": "[parameters('enableAutoHealOnInternalServerErrors')]",
@@ -316,7 +318,8 @@
             },
             "dependsOn": [
                 "[parameters('name')]",
-                "staging"
+                "staging",
+                "accesspolicies"
             ]
         },
         {


### PR DESCRIPTION
Make all config deployments depend on accessPolicies to avoid restarting without keyvault access (inconsistent behavior...)